### PR TITLE
fix: Improved text legibility on login/create account screens

### DIFF
--- a/src/routes/auth/connect.lazy.tsx
+++ b/src/routes/auth/connect.lazy.tsx
@@ -68,12 +68,12 @@ function Screen() {
 								placeholder="bunker://..."
 								value={uri}
 								onChange={(e) => setUri(e.target.value)}
-								className="pl-3 pr-12 rounded-lg w-full h-10 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:border-blue-500 focus:outline-none"
+								className="pl-3 pr-12 rounded-lg w-full h-10 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400"
 							/>
 							<button
 								type="button"
 								onClick={() => pasteFromClipboard()}
-								className="absolute top-1/2 right-2 transform -translate-y-1/2 text-xs font-semibold text-blue-500"
+								className="absolute top-1/2 right-2 transform -translate-y-1/2 text-xs font-semibold text-blue-500 dark:text-blue-300"
 							>
 								Paste
 							</button>

--- a/src/routes/auth/import.lazy.tsx
+++ b/src/routes/auth/import.lazy.tsx
@@ -84,12 +84,12 @@ function Screen() {
 									placeholder="nsec or ncryptsec..."
 									value={key}
 									onChange={(e) => setKey(e.target.value)}
-									className="pl-3 pr-12 rounded-lg w-full h-10 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400 dark:placeholder:text-neutral-600"
+									className="pl-3 pr-12 rounded-lg w-full h-10 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400"
 								/>
 								<button
 									type="button"
 									onClick={() => pasteFromClipboard()}
-									className="absolute uppercase top-1/2 right-2 transform -translate-y-1/2 text-xs font-semibold text-blue-500"
+									className="absolute top-1/2 right-2 transform -translate-y-1/2 text-xs font-semibold text-blue-500 dark:text-blue-300"
 								>
 									Paste
 								</button>

--- a/src/routes/auth/new.lazy.tsx
+++ b/src/routes/auth/new.lazy.tsx
@@ -110,7 +110,7 @@ function Screen() {
 								onChange={(e) => setName(e.target.value)}
 								placeholder="e.g. Alice"
 								spellCheck={false}
-								className="px-3 rounded-lg h-10 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:ring-0 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400 dark:text-neutral-600"
+								className="px-3 rounded-lg h-10 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:ring-0 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400 dark:text-neutral-200"
 							/>
 						</div>
 						<div className="flex flex-col gap-1">
@@ -126,7 +126,7 @@ function Screen() {
 								onChange={(e) => setAbout(e.target.value)}
 								placeholder="e.g. Artist, anime-lover, and k-pop fan"
 								spellCheck={false}
-								className="px-3 py-1.5 rounded-lg min-h-16 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:ring-0 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400 dark:text-neutral-600"
+								className="px-3 py-1.5 rounded-lg min-h-16 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:ring-0 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400 dark:text-neutral-200"
 							/>
 						</div>
 						<div className="h-px w-full mt-2 bg-neutral-100 dark:bg-neutral-900" />
@@ -142,7 +142,7 @@ function Screen() {
 								type="password"
 								value={password}
 								onChange={(e) => setPassword(e.target.value)}
-								className="px-3 rounded-lg h-10 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:ring-0 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400 dark:text-neutral-600"
+								className="px-3 rounded-lg h-10 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:ring-0 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400 dark:text-neutral-200"
 							/>
 						</div>
 					</Frame>

--- a/src/routes/index.lazy.tsx
+++ b/src/routes/index.lazy.tsx
@@ -148,7 +148,7 @@ function Screen() {
 													if (e.key === "Enter") loginWith();
 												}}
 												placeholder="Password"
-												className="px-3 rounded-full w-full h-10 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400 dark:placeholder:text-neutral-600"
+												className="px-3 rounded-full w-full h-10 bg-transparent border border-neutral-200 dark:border-neutral-500 focus:border-blue-500 focus:outline-none placeholder:text-neutral-400"
 											/>
 										</div>
 									) : (


### PR DESCRIPTION
Hi,

On different screens the text was hard to see as in dark mode the text and background were both dark colors.

**Login/Welcome back! Screen:**
- The placeholder text was not readable in dark mode as it was set to `placeholder:text-neutral-600` so I removed dark mode placeholder text styling as on other screens placeholder text color was set to `placeholder:text-neutral-400` which is both legible in dark and light mode.

**New Identity Screen:**
- I lowered the `dark:text-neutral-600` to `dark:text-neutral-200` as `neutral-600` was too dark to read in dark mode. `neutral-200` is the same as the `label` color so it aligns with that.

**Nostr Connect Screen:**
- Added `placeholder:text-neutral-400` as placeholder text was hard to see and aligns with the other placeholders.
- Text of the "paste" button was hard to read with it being dark blue on a dark background so lightened the blue a little to be easier to read for dark mode by adding the class `dark:text-blue-300`.

**Import Private Key Screen:**
- Added `placeholder:text-neutral-400` as placeholder text was hard to see and aligns with the other placeholders.
- Removed `uppercase` styling on the paste button and also added the class `dark:text-blue-300` to align with the other paste button.